### PR TITLE
Wrong pointer for example

### DIFF
--- a/examples/rainbow.js
+++ b/examples/rainbow.js
@@ -40,5 +40,5 @@ class Rainbow {
     }
 }
 
-let example = new Example();
+let example = new Rainbow();
 example.run();


### PR DESCRIPTION
example was pointing to an unidentified Class. Changed to point to Rainbow